### PR TITLE
Expose relative time and origin

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,10 +83,12 @@ interface SampleBufferFullEvent extends Event {
 }
 
 export interface ContinuousProfilerTrace extends ProfilerTrace {
-  /** Timestamp in milliseconds when profiler trace started. */
+  /** High resolution time when profiler trace started, relative to the profiling session's time origin */
   readonly start: number;
-  /** Timestamp in milliseconds when profiler trace ended. */
+  /** High resolution time when profiler trace ended, relative to the profiling session's time origin */
   readonly end: number;
+  /** Time origin of the profiling session */
+  readonly timeOrigin: number;
 }
 
 interface ContinuousProfilerInitOptions {
@@ -196,8 +198,9 @@ export class ContinuousProfiler {
       const end = performance.now();
       this.callback(
         Object.assign(trace, {
-          start: performance.timeOrigin + start,
-          end: performance.timeOrigin + end,
+          start,
+          end,
+          timeOrigin: performance.timeOrigin
         })
       );
     });

--- a/index.ts
+++ b/index.ts
@@ -91,7 +91,7 @@ export interface ContinuousProfilerTrace extends ProfilerTrace {
   readonly timeOrigin: number;
 }
 
-interface ContinuousProfilerInitOptions {
+export interface ContinuousProfilerInitOptions {
   /** Sample interval in milliseconds. */
   sampleInterval?: number;
   /** Collect interval in milliseconds. */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "continuous-profiler",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Continuous Profiler that runs inside a browser",
   "module": "index.js",
   "sideEffects": false,


### PR DESCRIPTION
Given that sample time stamp is relative to time origin, we should keep this information in the profiling trace. It make sense to keep start/end relative as well - this way every time field is the same type and we can translate this to real time stamp with time origin field.